### PR TITLE
Add setCookieDomain, trackerUrl and srcUrl options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ export default defineConfig({
     matomo({
       enabled: import.meta.env.PROD, // Only load in production
       host: "https://analytics.example.lol/",
+      setCookieDomain: "*.example.lol",
+      trackerUrl: "js/", // defaults to matomo.php
+      srcUrl: "js/", // defaults to matomo.js
       siteId: 666,
       heartBeatTimer: 5,
       disableCookies: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,10 @@ export type MatomoOptions = | {
   enabled: boolean,
   host: string,
   siteId: number,
+  trackerUrl?: string,
+  srcUrl?: string,
   heartBeatTimer?: number,
+  setCookieDomain?: string,
   disableCookies?: boolean,
   preconnect?: boolean,
   debug?: boolean

--- a/src/matomo.ts
+++ b/src/matomo.ts
@@ -13,6 +13,8 @@ export function initMatomo(options: MatomoOptions):void {
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   if (options?.disableCookies) _paq.push(['disableCookies']);
   if (options?.heartBeatTimer) _paq.push(['enableHeartBeatTimer', options.heartBeatTimer]);
+  if (options?.setCookieDomain) _paq.push(['setCookieDomain', options.setCookieDomain]);
+
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
 
@@ -25,7 +27,7 @@ export function initMatomo(options: MatomoOptions):void {
   (function() {
     const u = options?.host;
 
-    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+    _paq.push(['setTrackerUrl', u + options?.trackerUrl || 'matomo.php']);
     _paq.push(['setSiteId', options?.siteId]);
 
     const d = document,
@@ -36,7 +38,7 @@ export function initMatomo(options: MatomoOptions):void {
     g.type = 'text/javascript';
     g.async = true;
     g.defer = true;
-    g.src = u + 'matomo.js';
+    g.src = u +  options?.srcUrl || 'matomo.js';
     if (s.parentNode != null && u) s.parentNode.insertBefore(g, s);
   })();
 };

--- a/src/matomo.ts
+++ b/src/matomo.ts
@@ -27,7 +27,7 @@ export function initMatomo(options: MatomoOptions):void {
   (function() {
     const u = options?.host;
 
-    _paq.push(['setTrackerUrl', u + options?.trackerUrl || 'matomo.php']);
+    _paq.push(['setTrackerUrl', u + (options?.trackerUrl || 'matomo.php')]);
     _paq.push(['setSiteId', options?.siteId]);
 
     const d = document,
@@ -38,7 +38,7 @@ export function initMatomo(options: MatomoOptions):void {
     g.type = 'text/javascript';
     g.async = true;
     g.defer = true;
-    g.src = u +  options?.srcUrl || 'matomo.js';
+    g.src = u + (options?.srcUrl || 'matomo.js');
     if (s.parentNode != null && u) s.parentNode.insertBefore(g, s);
   })();
 };


### PR DESCRIPTION
Adds options to change the path to get matomo script and post data to matomo and setCookieDomain options for cross-domain tracking