### PR TITLE
Fix type extension import

### DIFF
--- a/src/matomo.ts
+++ b/src/matomo.ts
@@ -1,4 +1,4 @@
-import type { MatomoOptions } from "./index.js";
+import type { MatomoOptions } from "./index.ts";
 
 /**
  * Init Matomo


### PR DESCRIPTION
i don't know if it's a typo, but index extension is  .`ts`  not `.js `