### PR TITLE
feat: add preInitCommands option

### DIFF
--- a/packages/astro-matomo/README.md
+++ b/packages/astro-matomo/README.md
@@ -24,6 +24,7 @@ yarn add astro-matomo
 | `siteId`           | `number`                                | Matomo site id.                                                                                                                                                                                     |
 | `heartBeatTimer?`  | `number`                                | If set the heart beat timer will be enabled                                                                                                                                                         |
 | `disableCookies?`  | `boolean`                               | If set cookies will be disabled                                                                                                                                                                     |
+| `preInitCommands?` | `Array<[string, ...unknown[]]>`         | Matomo `_paq` commands pushed before default tracking commands. Use for calls like `requireCookieConsent`.                                                                                          |
 | `preconnect?`      | `boolean`                               | Will create a preconnect link pointing to the matomo host                                                                                                                                           |
 | `setCookieDomain?` | `string`                                | Share the tracking cookie across multiple domains                                                                                                                                                   |
 | `trackerUrl?`      | `string`                                | Defaults to matomo.php                                                                                                                                                                              |
@@ -55,6 +56,7 @@ export default defineConfig({
       siteId: 666,
       heartBeatTimer: 5,
       disableCookies: true,
+      preInitCommands: [["requireCookieConsent"]],
       debug: false,
       viewTransition: {
         contentElement: "main"

--- a/packages/astro-matomo/src/index.ts
+++ b/packages/astro-matomo/src/index.ts
@@ -1,5 +1,7 @@
 import type { AstroIntegration } from "astro";
 
+export type MatomoCommand = [string, ...unknown[]];
+
 export type MatomoOptions =
   | {
       enabled: boolean;
@@ -11,6 +13,7 @@ export type MatomoOptions =
       heartBeatTimer?: number;
       setCookieDomain?: string;
       disableCookies?: boolean;
+      preInitCommands?: MatomoCommand[];
       preconnect?: boolean;
       debug?: boolean;
       partytown?: boolean;

--- a/packages/astro-matomo/src/matomo.ts
+++ b/packages/astro-matomo/src/matomo.ts
@@ -11,6 +11,7 @@ export function initMatomo(options: MatomoOptions): void {
   const _paq = (window._paq = window._paq || []);
 
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  options?.preInitCommands?.forEach((command) => _paq.push(command));
   if (options?.disableCookies) _paq.push(["disableCookies"]);
   if (options?.heartBeatTimer)
     _paq.push(["enableHeartBeatTimer", options.heartBeatTimer]);

--- a/packages/astro-matomo/src/matomo.ts
+++ b/packages/astro-matomo/src/matomo.ts
@@ -5,6 +5,10 @@ import type { MatomoOptions } from "./index.ts";
  *
  * @param   {MatomoOptions}  options
  *
+ * @remarks preInitCommands values pass through JSON.stringify before
+ * injection — non-serializable values (functions, RegExp, Date, ...)
+ * silently become null at runtime.
+ *
  * @return  {void}
  */
 export function initMatomo(options: MatomoOptions): void {

--- a/packages/astro-matomo/src/types/index.d.ts
+++ b/packages/astro-matomo/src/types/index.d.ts
@@ -1,8 +1,8 @@
-export { };
+export {};
 
 declare global {
   interface Window {
-    _paq: Array<Array>;
-    _mtm: Array<Array>;
+    _paq: Array<[string, ...unknown[]]>;
+    _mtm: Array<[string, ...unknown[]]>;
   }
 }

--- a/packages/astro-matomo/src/types/index.d.ts
+++ b/packages/astro-matomo/src/types/index.d.ts
@@ -3,6 +3,14 @@ export {};
 declare global {
   interface Window {
     _paq: Array<[string, ...unknown[]]>;
-    _mtm: Array<[string, ...unknown[]]>;
+import type { MatomoCommand } from "../index.ts";
+
+export {};
+
+declare global {
+  interface Window {
+    _paq: Array<MatomoCommand | (() => void)>;
+    _mtm: Array<Record<string, unknown> | MatomoCommand>;
   }
 }
+


### PR DESCRIPTION
Some Matomo calls, like `requireCookieConsent`, must run before `trackPageView`. I think adding a generic `preInitCommands` is preferred instead of its own feature flag, as it is more future proof.
                                                                                                                                  
```js                                                                                                                                    
   matomo({                                                                                                                                 
     enabled: true,                                                                                                                         
     host: "https://analytics.example.com/",                                                                                                
     siteId: 1,                                                                                                                             
     preInitCommands: [["requireCookieConsent"]],                                                                                           
   })                                                                                                                                       
```                                                                                                                                        
                                                                                                                                      
- Added preInitCommands to README options table                                                                                            
- Added cookie-consent example to README usage
- (Cleanup the types file)