### PR TITLE
fix(spa mode): stop deleting custom dimension 1 on navigation

### DIFF
--- a/packages/astro-matomo/README.md
+++ b/packages/astro-matomo/README.md
@@ -32,7 +32,7 @@ yarn add astro-matomo
 | `debug?`           | `boolean`                               | Activate debug mode                                                                                                                                                                                 |
 | `partytown?`       | `boolean`                               | Adds [Partytown](https://partytown.builder.io/) support. Matomo added as: `<script type="text/partytown">...</script>`                                                                              |
 | `crossOrigin?`     | `string`                                | Set `crossorigin` attribute                                                                                                                                                                         |
-| `viewTransition?`  | `boolean or { contentElement: string }` | If true Matomo works in "SPA Mode" and will track every page visit after `astro:page-load`. When you pass a selector to `contentElement` Matomo is able to track new media files, forms and content |
+| `viewTransition?`  | `boolean or { contentElement?: string, deleteCustomDimensions?: number[] }` | If true Matomo works in "SPA Mode" and will track every page visit after `astro:page-load`. When you pass a selector to `contentElement` Matomo is able to track new media files, forms and content. Custom dimension ids listed in `deleteCustomDimensions` are deleted on every navigation (useful for page-scoped dimensions that should not leak into the next page view) |
 
 ## Example usage
 
@@ -57,7 +57,9 @@ export default defineConfig({
       disableCookies: true,
       debug: false,
       viewTransition: {
-        contentElement: "main"
+        contentElement: "main",
+        // Optional: delete page-scoped custom dimensions on every navigation
+        deleteCustomDimensions: [2, 3]
       }
     }),
   ]

--- a/packages/astro-matomo/src/index.ts
+++ b/packages/astro-matomo/src/index.ts
@@ -15,7 +15,9 @@ export type MatomoOptions =
       debug?: boolean;
       partytown?: boolean;
       crossOrigin?: string;
-      viewTransition?: boolean | { contentElement: string };
+      viewTransition?:
+        | boolean
+        | { contentElement?: string; deleteCustomDimensions?: number[] };
     }
   | undefined;
 

--- a/packages/astro-matomo/src/matomo.ts
+++ b/packages/astro-matomo/src/matomo.ts
@@ -61,6 +61,10 @@ export function initMatomo(options: MatomoOptions): void {
  */
 export function spaMode(options: MatomoOptions): void {
   let currentUrl = document.referrer;
+  const viewTransition =
+    typeof options?.viewTransition === "object"
+      ? options.viewTransition
+      : undefined;
 
   document.addEventListener("astro:after-swap", () => {
     const _paq = (window._paq = window._paq || []);
@@ -69,16 +73,13 @@ export function spaMode(options: MatomoOptions): void {
     _paq.push(["setCustomUrl", currentUrl]);
     _paq.push(["setDocumentTitle", document.title]);
     _paq.push(["deleteCustomVariables", "page"]);
-    _paq.push(["deleteCustomDimension", 1]);
+    for (const dimensionId of viewTransition?.deleteCustomDimensions ?? []) {
+      _paq.push(["deleteCustomDimension", dimensionId]);
+    }
     _paq.push(["trackPageView"]);
 
-    if (
-      typeof options?.viewTransition === "object" &&
-      options?.viewTransition
-    ) {
-      const content = document.querySelector(
-        options?.viewTransition?.contentElement
-      );
+    if (viewTransition?.contentElement) {
+      const content = document.querySelector(viewTransition.contentElement);
       _paq.push(["MediaAnalytics::scanForMedia", content]);
       _paq.push(["FormAnalytics::scanForForms", content]);
       _paq.push(["trackContentImpressionsWithinNode", content]);


### PR DESCRIPTION
The astro:after-swap handler unconditionally pushed
["deleteCustomDimension", 1], wiping any user-defined custom dimension
with id 1 after the first view transition. This call is not part of the
Matomo SPA tracking guide and its hardcoded id was arbitrary.

Remove the hardcoded call and add an opt-in
viewTransition.deleteCustomDimensions option so page-scoped dimensions
can still be reset on navigation when needed. contentElement is now
optional in the viewTransition object form.

Fixes #62

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013sJ4kg6V1KBwLpKkAbGXDv